### PR TITLE
Fix spawning of Node.js binaries (.cmd files) on Windows

### DIFF
--- a/lib/Spawn.js
+++ b/lib/Spawn.js
@@ -3,16 +3,17 @@ var spawn = require('child_process').spawn;
 function Spawn(stream, command, args, name, output) {
   var exited = false;
   var ended = false;
+  var spawnedProcess;
   var options;
 
   if (process.platform === 'win32') {
     options = {
       // required so that .bat/.cmd files can be spawned
-      shell: process.env.comspec || 'cmd.exe',
+      shell: process.env.comspec || 'cmd.exe'
     };
   }
 
-  var spawnedProcess = spawn(command, args, options);
+  spawnedProcess = spawn(command, args, options);
 
   this.id = name;
 

--- a/lib/Spawn.js
+++ b/lib/Spawn.js
@@ -3,7 +3,16 @@ var spawn = require('child_process').spawn;
 function Spawn(stream, command, args, name, output) {
   var exited = false;
   var ended = false;
-  var spawnedProcess = spawn(command, args);
+  var options;
+
+  if (process.platform === 'win32') {
+    options = {
+      // required so that .bat/.cmd files can be spawned
+      shell: process.env.comspec || 'cmd.exe',
+    };
+  }
+
+  var spawnedProcess = spawn(command, args, options);
 
   this.id = name;
 


### PR DESCRIPTION
This PR fixes running .bat/.cmd files on Windows (and .cmd files are used to wrap Node.js binaries installed via npm and yarn) by setting `shell` options of `child_process.spawn()` call on WIndows only.

Fixes #5 