### PR TITLE
Use `taskkill` instead of `.kill()` on Windows

### DIFF
--- a/lib/Spawn.js
+++ b/lib/Spawn.js
@@ -1,4 +1,4 @@
-var spawn = require('child_process').spawn;
+var child_process = require('child_process');
 
 function Spawn(stream, command, args, name, output) {
   var exited = false;
@@ -13,7 +13,7 @@ function Spawn(stream, command, args, name, output) {
     };
   }
 
-  spawnedProcess = spawn(command, args, options);
+  spawnedProcess = child_process.spawn(command, args, options);
 
   this.id = name;
 
@@ -52,7 +52,13 @@ function Spawn(stream, command, args, name, output) {
 
   process.on('exit', function(code) {
     if (exited === false) {
-      spawnedProcess.kill();
+      if (process.platform === 'win32') {
+        // Workaround for kill() not propagating to children of the cmd.exe we launched
+        // see https://github.com/nodejs/node/issues/3675#issuecomment-288578092
+        child_process.exec('taskkill /F /T /PID ' + spawnedProcess.pid);
+      } else {
+        spawnedProcess.kill();
+      }
     }
   });
 

--- a/lib/Spawn.js
+++ b/lib/Spawn.js
@@ -55,7 +55,9 @@ function Spawn(stream, command, args, name, output) {
       if (process.platform === 'win32') {
         // Workaround for kill() not propagating to children of the cmd.exe we launched
         // see https://github.com/nodejs/node/issues/3675#issuecomment-288578092
-        child_process.exec('taskkill /F /T /PID ' + spawnedProcess.pid);
+        // Uses sync version otherwise there is a race on shutdown where the cmd.exe will exit before
+        // taskkill can find it to determine the children we want to kill.
+        child_process.spawnSync('taskkill', ['/F', '/T', '/PID', String(spawnedProcess.pid)]);
       } else {
         spawnedProcess.kill();
       }


### PR DESCRIPTION
This fixes https://github.com/arjunmehta/multiview/issues/10
I've tested on my own windows machine and it has the intended behaviour of killing the tree of processes spawned indirectly through the CMD.